### PR TITLE
Cleanup prior customization

### DIFF
--- a/src/SpectralFits.jl
+++ b/src/SpectralFits.jl
@@ -57,7 +57,7 @@ export nonlinear_inversion, profile_inversion, fit_spectra, run_inversion
 export process_all_files
 
 # some useful funcs fom utils.jl
-export assemble_state_vector!
+export assemble_state_vector!, prior_shape_params
 export make_vcd_profile, calc_gain_matrix
 
 # certain packages visible to the user

--- a/src/forward_model.jl
+++ b/src/forward_model.jl
@@ -15,9 +15,9 @@
 - returns:
 transmission::Vector: the calculated tranmission
 """
-function calculate_transmission(x::AbstractDict{String, Union{FT, Vector{FT}}}, pathlength::Real, spectra::AbstractDict, grid_length::Int; p::Real=1000, T::Real=290) where FT <: Real
+function calculate_transmission(x::StateVector, pathlength::Real, spectra::AbstractDict, grid_length::Int; p::Real=1000, T::Real=290)
 
-    #molecules = collect(keys(spectra))
+    FT = dicttype(x)
     τ = zeros(FT, grid_length)
     vcd = calc_vcd(p, T, pathlength)
     
@@ -28,9 +28,9 @@ function calculate_transmission(x::AbstractDict{String, Union{FT, Vector{FT}}}, 
     return exp.(-τ)
 end
 
-function calculate_transmission(x::AbstractDict{String, Union{FT, Vector{FT}}}, spectra::AbstractDict, grid_length::Int; p::Real=1000, T::Real=300) where FT <: Real
+function calculate_transmission(x::StateVector, spectra::AbstractDict, grid_length::Int; p::Real=1000, T::Real=300)
 
-    #k = collect(keys(spectra))
+    FT = dicttype(x)
     τ = zeros(FT, grid_length)
     
     for molecule in keys(spectra)
@@ -42,13 +42,14 @@ end
 
 
 """calculate transmission in a profile with multiple layers"""
-function calculate_transmission(xₐ::AbstractDict{String,Vector{FT}}, spectra::AbstractDict, p::Vector{<:Real}, T::Vector{<:Real}; input_is_column=false) where FT <: Real
+function calculate_transmission(xₐ::ProfileStateVector, spectra::AbstractDict, p::Vector{<:Real}, T::Vector{<:Real}; input_is_column=false)
     
 
 
     n_levels = length(p)
     vcd = input_is_column ? ones(n_levels) : make_vcd_profile(p, T)
     molecules = collect(keys(spectra))
+    FT = dicttype(xₐ)
     τ = zeros(FT, length(spectra[molecules[1]].grid))
     
     for i = 1:n_levels

--- a/src/inversion.jl
+++ b/src/inversion.jl
@@ -1,7 +1,7 @@
 
 function make_obs_error(measurement::AbstractMeasurement;
                         σ²::Union{Nothing, Float64}=nothing,
-                        masked_indexes::Union{Vector{Int64}, Nothing}=nothing)
+                        masked_windows::Union{AbstractArray{<:Real}, Nothing}=nothing)
     
     n = length(measurement.intensity)
     base = mean(measurement.intensity)
@@ -15,7 +15,12 @@ function make_obs_error(measurement::AbstractMeasurement;
     value = @. 1/noise * ones(n)
     Sₑ⁻¹ = Diagonal(value)
 
-    if masked_indexes != nothing
+    if masked_windows != nothing
+        masked_indexes = find_mask(measurement.grid, masked_windows)
+        
+        # the windows are outside the range of the grid
+        if isempty(masked_indexes); return Sₑ⁻¹; end
+        
         for i in masked_indexes
             Sₑ⁻¹[i,i] = 1/(1e5 * noise)
         end
@@ -65,9 +70,9 @@ function nonlinear_inversion(f, x₀::AbstractDict, measurement::AbstractMeasure
     if haskey(inversion_setup, "obs_covariance")
         println("Using user-defined covariance")
         Sₑ⁻¹ = inversion_setup["obs_covarience"]
-    elseif haskey(inversion_setup, "masked_indexes")
+    elseif haskey(inversion_setup, "masked_windows")
         println("masking out selected wave-numbers")
-        Sₑ⁻¹ = make_obs_error(measurement, masked_indexes=inversion_setup["masked_indexes"])
+        Sₑ⁻¹ = make_obs_error(measurement, masked_windows=inversion_setup["masked_windows"])
     else
         println("default covariance")
         Sₑ⁻¹ = make_obs_error(measurement)
@@ -95,14 +100,14 @@ function nonlinear_inversion(f, x₀::AbstractDict, measurement::AbstractMeasure
         
         #result = DiffResults.JacobianResult(measurement.grid, xᵢ);
          #ForwardDiff.jacobian!(result, f, xᵢ)#,
-         try
+#         try
              result = jf!(result, xᵢ)
              x_old = copy(xᵢ)
              fᵢ[:], kᵢ[:,:] = result.value, result.derivs[1]
-         catch error
-             println(" jacobian and forward model calculation has failed")
-             return failed_inversion(x₀, measurement)
-         end
+#         catch error
+#             println(" jacobian and forward model calculation has failed")
+#             return failed_inversion(x₀, measurement)
+#         end
          
 
         # Gauss-Newton Algorithm

--- a/src/types.jl
+++ b/src/types.jl
@@ -35,7 +35,7 @@ abstract type AbstractResults end
 Base.@kwdef mutable struct InversionResults{FT} <: AbstractResults
     timestamp::DateTime
     machine_time::FT
-    x::Union{AbstractDict{String, Union{FT, Vector{FT}}}, AbstractDict{String, Vector{FT}}}
+    x::AbstractDict
     measurement::Array{FT,1}
     model::Array{FT,1}
     χ²::FT

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -74,19 +74,30 @@ function make_vcd_profile(p::Array{<:Real,1}, T::Array{<:Real,1}; vmr_H₂O=noth
     return vcd
 end
 
+function dicttype(x::AbstractDict)
+    k = collect(keys(x))
+    FT = eltype(x[k[1]])
+    return FT
+end
+
+
 """Convert a state vector{Dict} to an Array"""
-function assemble_state_vector!(x::Union{AbstractDict{String, Union{FT, Vector{FT}}}, AbstractDict{String, Vector{FT}}}) where FT<:Real
-    out::Array{FT,1} = []
+function assemble_state_vector!(x::Union{StateVector, ProfileStateVector})
+
+    key = collect(keys(x))
+    FT = eltype(x[key[1]])
+    out::Vector{FT} = []
     for key in keys(x)
         out = append!(out, x[key])
-        end
+    end
+    println(FT)
     return out
 end #function assemble_state_vector!
 
 """Convert the state vecotr{Array} to a Dict"""
 function assemble_state_vector!(x::Vector{FT}, key_vector, inversion_setup::AbstractDict) where FT <: Real
 
-    out::OrderedDict{String, Union{FT, Vector{FT}}} = OrderedDict([key_vector[i] => x[i] for i=1:length(key_vector)-1])
+    out::StateVector = OrderedDict([key_vector[i] => x[i] for i=1:length(key_vector)-1])
     out = push!(out, "shape_parameters" => x[end-inversion_setup["poly_degree"]+1:end])
     return out
 end #function assemble_state_vector!
@@ -94,7 +105,7 @@ end #function assemble_state_vector!
 
 """Convert the state vecotr{Array} to a Dict"""
 function assemble_state_vector!(x::Array{FT,1}, fields::AbstractArray, num_levels::Integer, inversion_setup::AbstractDict) where FT<:Real
-    out::OrderedDict{String, Vector{FT}} = OrderedDict([fields[i] => x[1+(i-1)*num_levels : i*num_levels] for i=1:length(fields)-1])
+    out::ProfileStateVector = OrderedDict([fields[i] => x[1+(i-1)*num_levels : i*num_levels] for i=1:length(fields)-1])
     out = push!(out, "shape_parameters" => x[end-inversion_setup["poly_degree"]+1:end])
     return out
 end
@@ -224,5 +235,14 @@ function calc_DCS_noise(grid::Array{Float64,1}, intensity::Array{Float64,2})
     return σ.^2
 end
 
-
+"""Find the indexes of the spectral windows being masked"""
+function find_mask(spectral_grid::Vector{<:Real}, # spectral grid 
+                   masked_windows::Array{<:Real,2}) # spectral windows to mask in the form [ν₁, ν₂]
+    
+    # Find all indices in the grid that is within the subwindows:
+    all = [findall(i -> (i>masked_windows[j,1])&(i<masked_windows[j,2]), spectral_grid) for j=1:size(masked_windows,1)];
+    
+    # Return all indices:
+    vcat(all...)
+end
     

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -139,25 +139,6 @@ function calc_χ²(result::InversionResults)
     return χ²
 end
 
-"""convert an array of arrays to an array"""
-function list2array(array_in::Array)
-    outer_dim, inner_dim = length(array_in), length(array_in[1])
-    data_type = typeof(array_in[1][1])
-
-    # allocate memory
-    array_out = Array{data_type}(undef, (outer_dim, inner_dim))
-    v = VectorOfArray(array_in)
-    array_out = convert(Array, v)
-    return array_out'
-end
-
-"""convert an array of arrays to an array"""
-function list2array!(array_out::Array, array_in::Array)
-    v = VectorOfArray(array_in)
-    array_out = convert(Array, v)
-    return array_out'
-end
-
 function calc_DCS_noise(data::FrequencyCombDataset)
 
     # select spectrally flat region 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -90,7 +90,6 @@ function assemble_state_vector!(x::Union{StateVector, ProfileStateVector})
     for key in keys(x)
         out = append!(out, x[key])
     end
-    println(FT)
     return out
 end #function assemble_state_vector!
 
@@ -133,6 +132,13 @@ function compute_legendre_poly(x::Array{<:Real,1}, nmax::Integer)
     return P⁰
 end  
 
+
+function prior_shape_params(dataset::AbstractDataset,
+                            inversion_setup::AbstractDict)
+    return [maximum(dataset.intensity); zeros(inversion_setup["poly_degree"]-1)]
+end
+
+    
 """Calculate the gain matrix from InversionResults fields"""
 function calc_gain_matrix(inversion_results::InversionResults)
     G = inv(inversion_results.K'*inversion_results.Sₑ⁻¹*inversion_results.K + inversion_results.Sₐ⁻¹)*inversion_results.K'*inversion_results.Sₑ⁻¹


### PR DESCRIPTION
In the case the user wants to filter out undesired lines or instrument features, The user can now define spectral windows and the prior error covariance matrix will select those windows, unweight them, and run the retrieval. These undesired/noisy windows will be less weighted in the retrieval and not affect the result 